### PR TITLE
Add Camera/Contacts/Mic usage descriptions to prevent crash on iOS 10

### DIFF
--- a/BankingAppObjectiveC/BankingApp/Info.plist
+++ b/BankingAppObjectiveC/BankingApp/Info.plist
@@ -22,6 +22,12 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSCameraUsageDescription</key>
+	<string>Access to the camera is required for making video calls.</string>
+	<key>NSContactsUsageDescription</key>
+	<string>Access to your address book is required for making calls to contacts.</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Access to the microphone is required for making calls.</string>
 	<key>Skype meeting URL</key>
 	<string>SkypeMeetingURL</string>
 	<key>Skype meeting display name</key>

--- a/BankingAppSwift/BankingAppSwift/Info.plist
+++ b/BankingAppSwift/BankingAppSwift/Info.plist
@@ -22,6 +22,12 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSCameraUsageDescription</key>
+	<string>Access to the camera is required for making video calls.</string>
+	<key>NSContactsUsageDescription</key>
+	<string>Access to your address book is required for making calls to contacts.</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Access to the microphone is required for making calls.</string>
 	<key>Skype meeting URL</key>
 	<string>SkypeMeetingUrl</string>
 	<key>Skype meeting display name</key>

--- a/GuestMeetingJoin/SfBDemo/Info.plist
+++ b/GuestMeetingJoin/SfBDemo/Info.plist
@@ -22,6 +22,12 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSCameraUsageDescription</key>
+	<string>Access to the camera is required for making video calls.</string>
+	<key>NSContactsUsageDescription</key>
+	<string>Access to your address book is required for making calls to contacts.</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Access to the microphone is required for making calls.</string>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>audio</string>


### PR DESCRIPTION
iOS 10 now requires applications provide a string when requesting access to resources. I've added the necessary strings for Camera, Contacts and Microphone so that the sample applications do not crash when starting or joining a call on iOS 10.