### PR TITLE
Add support for a URL scheme in the GuestMeetingJoin demo

### DIFF
--- a/GuestMeetingJoin/SfBDemo/AppDelegate.swift
+++ b/GuestMeetingJoin/SfBDemo/AppDelegate.swift
@@ -29,6 +29,39 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         return true
     }
 
+	func application(application: UIApplication, openURL url: NSURL, sourceApplication: String?, annotation: AnyObject) -> Bool {
+		// The URL scheme should follow the format 'sfbmeeting://FirstName%20LastName@tenant/user/meetingID'
+        if url.host == nil {
+			return false;
+		}
+		let urlComponents = url.absoluteString!.stringByRemovingPercentEncoding!.componentsSeparatedByString("/")
+		if urlComponents.count != 5 {
+            return false;
+        }
+        let partialData = urlComponents[2].componentsSeparatedByString("@")
+        let displayName = partialData[0]
+        let meetingUriComponents = ["https://meet.lync.com/", partialData[1]] + urlComponents[3...4]
+
+        // Join the meeting
+        let navController:UINavigationController = window!.rootViewController as! UINavigationController
+        if navController.topViewController is IdentityViewController {
+            let dstController = navController.topViewController as! IdentityViewController
+            navController.popToViewController(dstController, animated: true)
+            if #available(iOS 9.0, *) {
+                dstController.loadViewIfNeeded()
+            } else {
+                let _ = dstController.view;
+            }
+            dstController.loadMeeting(meetingUriComponents.joinWithSeparator("/"), displayName: displayName)
+            dstController.performSegueWithIdentifier("JoinConversation", sender: nil)
+            return true
+        }
+        else {
+            UIAlertView(title: "Join failed", message: "You are currently in another meeting.", delegate: nil, cancelButtonTitle: "OK").show()
+        }
+        return false
+	}
+
     func applicationWillResignActive(application: UIApplication) {
         // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
         // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.

--- a/GuestMeetingJoin/SfBDemo/Base.lproj/Main.storyboard
+++ b/GuestMeetingJoin/SfBDemo/Base.lproj/Main.storyboard
@@ -37,7 +37,7 @@
                                 <rect key="frame" x="285" y="323" width="30" height="30"/>
                                 <state key="normal" title="Join"/>
                                 <connections>
-                                    <segue destination="CQB-gl-sgB" kind="show" id="VWG-4q-3oL"/>
+                                    <segue destination="CQB-gl-sgB" kind="show" identifier="JoinConversation" id="VWG-4q-3oL"/>
                                 </connections>
                             </button>
                         </subviews>

--- a/GuestMeetingJoin/SfBDemo/IdentityViewController.swift
+++ b/GuestMeetingJoin/SfBDemo/IdentityViewController.swift
@@ -32,14 +32,19 @@ class IdentityViewController: UIViewController, SfBAlertDelegate {
         alert.show()
     }
 
+	func loadMeeting(meetingUrl: String, displayName: String) -> Bool {
+		do {
+			let url = NSURL(string: meetingUrl)!;
+			conversation = try sfb.joinMeetingAnonymousWithUri(url, displayName: displayName)
+			return true
+		} catch {
+			UIAlertView(title: "Join failed", message: "\(error)", delegate: nil, cancelButtonTitle: "OK").show()
+			return false
+		}
+	}
+
     override func shouldPerformSegueWithIdentifier(identifier: String, sender: AnyObject?) -> Bool {
-        do {
-            conversation = try sfb.joinMeetingAnonymousWithUri(NSURL(string: meetingUrl.text!)!, displayName: displayName.text!)
-            return true
-        } catch {
-            UIAlertView(title: "Join failed", message: "\(error)", delegate: nil, cancelButtonTitle: "OK").show()
-            return false
-        }
+		return loadMeeting(meetingUrl.text!, displayName: displayName.text!)
     }
 
     override func prepareForSegue(segue: UIStoryboardSegue, sender: AnyObject?) {

--- a/GuestMeetingJoin/SfBDemo/Info.plist
+++ b/GuestMeetingJoin/SfBDemo/Info.plist
@@ -18,6 +18,17 @@
 	<string>0.1.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+			<dict>
+					<key>CFBundleURLName</key>
+					<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+					<key>CFBundleURLSchemes</key>
+					<array>
+							<string>sfbmeeting</string>
+					</array>
+			</dict>
+	</array>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>


### PR DESCRIPTION
URLs follow format 'sfbmeeting://DisplayName@tenant/author/meetingID'. DisplayName can be URL-encoded, for example "sfbmeeting://Stewart%20Adam@tenant/foo/bar/ABC123" to set my display name to "Stewart Adam".
